### PR TITLE
Fix app name to vibeAPI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ const nunito = Nunito({
 })
 
 export const metadata: Metadata = {
-  title: "vibecode - Workflow Automator",
+  title: "vibeAPI - Workflow Automator",
   description: "A minimal workflow automator with step-based automation",
     generator: 'v0.dev'
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -136,7 +136,7 @@ export default function Home() {
       <header className="w-full flex justify-between items-center mb-8 mt-2">
         <div className="flex items-center">
           <div className="w-[60px] h-[60px] rounded-xl bg-gradient-to-br from-orange-400 to-orange-500 mr-2"></div>
-          <span className="font-bold text-[2.5rem]">vibecode</span>
+          <span className="font-bold text-[2.5rem]">vibeAPI</span>
         </div>
 
         {workflowSteps.length > 0 && (


### PR DESCRIPTION
## Summary
- rename all vibecode references to vibeAPI

## Testing
- `npm run lint` *(fails: `next` not found)*